### PR TITLE
Add getSnapshotsByAppId to TokenService

### DIFF
--- a/library/src/main/kotlin/one/mixin/bot/api/call/TokenCallService.kt
+++ b/library/src/main/kotlin/one/mixin/bot/api/call/TokenCallService.kt
@@ -50,6 +50,13 @@ interface TokenCallService {
     ): Call<MixinResponse<List<SafeSnapshot>>>
 
     @GET("safe/snapshots")
+    fun getSnapshotsByAppIdCall(
+        @Query("app") id: String,
+        @Query("offset") offset: String? = null,
+        @Query("limit") limit: Int = LIMIT,
+    ): Call<MixinResponse<List<SafeSnapshot>>>
+
+    @GET("safe/snapshots")
     fun getAllSnapshotsCall(
         @Query("offset") offset: String? = null,
         @Query("limit") limit: Int = LIMIT,

--- a/library/src/main/kotlin/one/mixin/bot/api/coroutine/TokenCoroutineService.kt
+++ b/library/src/main/kotlin/one/mixin/bot/api/coroutine/TokenCoroutineService.kt
@@ -50,6 +50,13 @@ interface TokenCoroutineService {
     ): MixinResponse<List<SafeSnapshot>>
 
     @GET("safe/snapshots")
+    suspend fun getSnapshotsByAppId(
+        @Query("app") id: String,
+        @Query("offset") offset: String? = null,
+        @Query("limit") limit: Int = LIMIT,
+    ): MixinResponse<List<SafeSnapshot>>
+
+    @GET("safe/snapshots")
     suspend fun getAllSnapshots(
         @Query("offset") offset: String? = null,
         @Query("limit") limit: Int = LIMIT,


### PR DESCRIPTION
Adding support for the `app` parameter to the `safe/snapshots` API per the documentation.

> If the authentication information of the request for this API is a robot, you can add the app parameter to return the snapshots of all sub-users created by this robot.

https://developers.mixin.one/docs/api/safe-apis#snapshot